### PR TITLE
incorporated recent hotfix to main WISDEM/WEIS branch that affects successful installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The installation instructions below use the environment name, "weis-env," but an
 
 1.  Setup and activate the Anaconda environment from a prompt (WSL terminal on Windows or Terminal.app on Mac)
 
-        conda env create --name weis-env -f https://raw.githubusercontent.com/WISDEM/WEIS/develop/environment.yml python=3.9
+        conda env create --name weis-env -f https://raw.githubusercontent.com/DeepFriedDerp/WEIS-DAC_bb_featuredevelopment/main/environment.yml python=3.9
         conda activate weis-env                          # (if this does not work, try source activate weis-env)
         sudo apt update                                  # (WSL only, assuming Ubuntu)
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - markupsafe
   - matplotlib-base
   - nlopt
-  - numpy
+  - numpy=1.23.1
   - numpydoc
   - openmdao
   - openpyxl
@@ -64,6 +64,7 @@ dependencies:
   - pip:
     - fatpack
     - marmot-agents
+    - mat4py
 # Needs to be done outside of environment file:
 #  - m2w64-toolchain # [win]
 #  - libpython # [win]


### PR DESCRIPTION
Constrained numpy version to prevent runtime errors, and edited the repo's installation instructions to point to this repo's conda environment.yaml file, instead of the official WEIS main branch's. This avoids installation issues should the official WEIS main branch be updated. 