### PR TITLE
Hot fix for not needing xfoil path when using LEMS

### DIFF
--- a/WISDEM/wisdem/ccblade/ccblade.py
+++ b/WISDEM/wisdem/ccblade/ccblade.py
@@ -453,6 +453,12 @@ class CCAirfoil(object):
         if os.path.exists(NUL_fname):
             os.remove(NUL_fname)
 
+    def af_dac_coords_lems(
+        self, dac_coords_x,dac_coords_y
+    ):
+        self.af_dac_xcoords = dac_coords_x
+        self.af_dac_ycoords = dac_coords_y
+
 
 # ------------------
 #  Main Class: CCBlade

--- a/weis/control/dac.py
+++ b/weis/control/dac.py
@@ -359,7 +359,10 @@ class RunXFOIL(ExplicitComponent):
                         for ind, fa in enumerate(dac_param):
                             # NOTE: negative flap angles are deflected to the suction side, i.e. positively along the positive z- (radial) axis
                             af_dac = CCAirfoil(np.array([1,2,3]), np.array([100]), np.zeros(3), np.zeros(3), np.zeros(3), inputs['coord_xy_interp'][i,:,0], inputs['coord_xy_interp'][i,:,1], "Profile"+str(i)) # bem:I am creating an airfoil name based on index...this structure/naming convention is being assumed in CCAirfoil.runXfoil() via the naming convention used in CCAirfoil.af_dac_coords(). Note that all of the inputs besides profile coordinates and name are just dummy varaiables at this point.
-                            af_dac.af_dac_coords(self.xfoil_path, fa* 180. / np.pi,  inputs['chord_start'][k],0.5,200, **xfoil_kw) #bem: the last number is the number of points in the profile.  It is currently being hard coded at 200 but should be changed to make sure it is the same number of points as the other profiles
+                            if self.dac_model == 1:
+                                af_dac.af_dac_coords(self.xfoil_path, fa* 180. / np.pi,  inputs['chord_start'][k],0.5,200, **xfoil_kw) #bem: the last number is the number of points in the profile.  It is currently being hard coded at 200 but should be changed to make sure it is the same number of points as the other profiles
+                            else:
+                                af_dac.af_dac_coords_lems(inputs['coord_xy_interp'][i,:,0], inputs['coord_xy_interp'][i,:,1]) # Just passing zeros...doesn't matter for generic dac model
                             # self.flap_profiles[i]['coords'][:,0,ind] = af_flap.af_flap_xcoords # x-coords from xfoil file with flaps
                             # self.flap_profiles[i]['coords'][:,1,ind] = af_flap.af_flap_ycoords # y-coords from xfoil file with flaps
                             # self.flap_profiles[i]['coords'][:,0,ind] = af_flap.af_flap_xcoords  # x-coords from xfoil file with flaps and NO gaussian filter for smoothing

--- a/weis/glue_code/gc_LoadInputs.py
+++ b/weis/glue_code/gc_LoadInputs.py
@@ -130,7 +130,7 @@ class WindTurbineOntologyPythonWEIS(WindTurbineOntologyPython):
                                                   self.modeling_options['Level3']['flag'])
         
         # XFoil
-        if not osp.isfile(self.modeling_options['Level3']["xfoil"]["path"]) and self.modeling_options['ROSCO']['DAC_Mode']:
+        if not osp.isfile(self.modeling_options['Level3']["xfoil"]["path"]) and self.modeling_options['ROSCO']['DAC_Model'] == 1:
             raise Exception("A distributed aerodynamic control device is defined in the geometry yaml, but the path to XFoil in the modeling options is not defined correctly")
 
         # Compute the number of DLCs that will be run


### PR DESCRIPTION
@Ben-Mertz's hot fix to address and unnecessary parameter error when using LEMS without a specified xfoil path. In the case of LEMS, xfoil is not used, thus the xfoil path parameter is not needed, and doesn't require a parameter error when the xfoil path parameter is not specified. 